### PR TITLE
[WIP] Refactor background, increase version, remove permission

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,3 @@
+Contributors of the DWDS.org Browser Add-On
+* Adrien Barbaresi
+* Armin Kunkel

--- a/README.md
+++ b/README.md
@@ -8,4 +8,9 @@ This extension allows for
 - forwarding selected text to the DWDS search page on right-click
 - typing dwds in the address bar to trigger a link suggestion corresponding to user input
 
-Firefox add-on page: [https://addons.mozilla.org/firefox/addon/dwds/](https://addons.mozilla.org/firefox/addon/dwds/)
+* Firefox add-on page: [https://addons.mozilla.org/firefox/addon/dwds/](https://addons.mozilla.org/firefox/addon/dwds/)  
+* Chrome Webstore search: [https://chrome.google.com/webstore/category/extensions](https://chrome.google.com/webstore/category/extensions)  
+
+
+[Publish to Webstore](https://developer.chrome.com/docs/webstore/publish/)  
+[Why manifest v3](https://developer.chrome.com/docs/extensions/mv2/)

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -xe
+
+cd src
+rm -Rf web-ext-artifacts/
+version=$(grep -E "\"version\": \"" manifest.json | grep -o "[0-9]*\.[0-9]*\.[0-9]*")
+
+mv manifest-chrome.json ../manifest-chrome.json
+web-ext build
+mv web-ext-artifacts/im_dwds_nachschlagen-$version.zip ../im_dwds_nachschlagen-$version-firefox.zip
+
+mv manifest.json ../manifest-firefox.json
+mv ../manifest-chrome.json manifest.json
+
+web-ext build
+mv web-ext-artifacts/im_dwds_nachschlagen-$version.zip ../im_dwds_nachschlagen-$version-chrome.zip
+
+mv manifest.json manifest-chrome.json
+mv ../manifest-firefox.json manifest.json

--- a/src/background.js
+++ b/src/background.js
@@ -1,71 +1,108 @@
+/**
+ * Some functionality can be used the same way with both API's!
+ * Firefox and Safari: browser
+ * Chrome, Opera, Edge: chrome
+ * See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension
+ */
+const isFirefox = (typeof browser === 'object')
+const pluginApi = (isFirefox ? browser : chrome)
+const contextMenu = isFirefox ? browser.menus : chrome.contextMenus
+
 // display text according to current locale
-var menuText = browser.i18n.getMessage("menuContent");
-var omniboxSuggestion = browser.i18n.getMessage("omniboxSuggestion");
-var omniboxText = browser.i18n.getMessage("omniboxText");
+const menuText = pluginApi.i18n.getMessage("menuContent")
+const omniboxSuggestion = pluginApi.i18n.getMessage("omniboxSuggestion")
+const omniboxText = pluginApi.i18n.getMessage("omniboxText")
 
 // construct queries starting from this URL
-const baseURL = "https://www.dwds.de/?q=";
-
+const baseURL = "https://www.dwds.de/?q="
+const suggestionBaseURL = "https://www.dwds.de/wb/typeahead?q="
 
 /*
-Create a menu item for the search engine
-*/
-function createMenuItem(engines) {
-  browser.menus.create({
+ Actions to execute only when the add-on is installed or updated
+ See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onInstalled
+ */
+pluginApi.runtime.onInstalled.addListener(() => {
+  /*
+   Create a contextmenu entry and tell the browser to show this entry only when text is selected.
+   See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/create
+   */
+  contextMenu.create({
     id: "dwds",
     title: menuText,
     contexts: ["selection"]
-  });
-}
-
-browser.search.get().then(createMenuItem);
+  })
+})
 
 
 /*
-Search using the search engine whose name matches the
-menu item's ID.
+When the contextmenu item is clicked:
+In Firefox -> search using the search engine with name "DWDS" declared in the manifest
+In Chrome -> create a new tab with the URL of DWDS (since in Chrome no engine can be selected)
+See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/onClicked
 */
-browser.menus.onClicked.addListener((info, tab) => {
-  browser.search.search({
-    query: info.selectionText,
-    engine: "DWDS"
-  });
-});
-
-
-/*
-Use omnibox to trigger DWDS query on user's request
-*/
-browser.omnibox.setDefaultSuggestion({
-  description: omniboxSuggestion
-});
-
-
-function getSuggestions(input) {
-  var result = [];
-  let suggestion = {
-    content: baseURL + input,
-    description: omniboxText
+contextMenu.onClicked.addListener((info, tab) => {
+  if (info.menuItemId === 'dwds') {
+    if (isFirefox) {
+      browser.search.search({
+        query: info.selectionText,
+        engine: "DWDS"
+      })
+    } else {
+      chrome.tabs.create({url: baseURL + info.selectionText})
+    }
   }
-  result.push(suggestion);
-  return result;
+})
+
+
+/*
+Set the default suggestion description
+See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/setDefaultSuggestion
+*/
+pluginApi.omnibox.setDefaultSuggestion({
+  description: omniboxSuggestion
+})
+
+
+async function getSuggestions(input) {
+  const result = []
+  await fetch(suggestionBaseURL + input)
+    .then(res => res.json())
+    .then(res => {
+      for (const suggestion of res) {
+        result.push({
+          content: baseURL + suggestion.value,
+          description: `${suggestion.value}`
+        })
+      }
+    }).catch(console.error)
+
+    return result
 }
 
 
-browser.omnibox.onInputChanged.addListener((input, suggest) => {
-  suggest(getSuggestions(input));
-});
+/*
+See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/onInputChanged
+ */
+pluginApi.omnibox.onInputChanged.addListener(async (input, suggest) => {
+  suggest(await getSuggestions(input))
+})
 
-browser.omnibox.onInputEntered.addListener((url, disposition) => {
+/*
+See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/omnibox/onInputEntered
+ */
+pluginApi.omnibox.onInputEntered.addListener((url, disposition) => {
+  if (!url.startsWith(baseURL)) {
+    url = baseURL + url
+  }
   switch (disposition) {
     case "currentTab":
-      browser.tabs.update({url});
-      break;
+      pluginApi.tabs.update({url})
+      break
     case "newForegroundTab":
-      browser.tabs.create({url});
-      break;
+      pluginApi.tabs.create({url})
+      break
     case "newBackgroundTab":
-      browser.tabs.create({url, active: false});
-      break;
+      pluginApi.tabs.create({url, active: false})
+      break
   }
-});
+})

--- a/src/manifest-chrome.json
+++ b/src/manifest-chrome.json
@@ -4,13 +4,8 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "version": "0.2.0",
-  "default_locale": "de",
 
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "browser-addon@dwds.de"
-    }
-  },
+  "default_locale": "de",
 
   "icons": {
     "16": "icons/favicon-16.png",
@@ -24,11 +19,11 @@
   "omnibox": { "keyword" : "dwds" },
 
   "background": {
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
 
   "permissions": [
-    "menus",
+    "contextMenus",
     "search"
   ],
 


### PR DESCRIPTION
This pull request refactors the background script, so that this can be used in **firefox** and **chromium** based browsers like Chrome, Opera, Edge.

Also a manifest file for deploying as a chrome extension is created witrh this PR.
The version of the manifest itself is increased to 3. In the README file you can find an answer to why using v3.

In the README also links to the Chrome Webstore and how to publish to the Webstore was added.

I have tested functioning of the plugin successfully with **firefox** and **chrome**. Opera is not working with manifest version 3 for now. Another manifest for Opera should do the trick, but seems a bit strange, since another manifest is needed for version 3 but one is enough for version 2.

All in all this PR refactors the background script, increases the manifest version, removes unnecessary permissions and add some Chrome webstore and manfest version related links to README.

To load the plugin manually into the browsers for testing, you can use:
* For Chrome: `chrome://extensions/`
* For Firefox: `about:debugging#/runtime/this-firefox`
* For Opera: `opera://extensions`

For Chrome and Opera the manifest file must be renamed to `manifest.json` and the current one be stashed or removed.