### PR TITLE
Decreases firefox manifest version and use extension ID

### DIFF
--- a/src/manifest-chrome.json
+++ b/src/manifest-chrome.json
@@ -4,7 +4,6 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "version": "0.2.0",
-
   "default_locale": "de",
 
   "icons": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
 
-  "manifest_version": 3,
+  "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "version": "0.2.0",
@@ -8,7 +8,7 @@
 
   "browser_specific_settings": {
     "gecko": {
-      "id": "browser-addon@dwds.de"
+      "id": "{6cce5e2b-010d-4403-a0de-938d9a0a587f}"
     }
   },
 


### PR DESCRIPTION
This PR decreases the firefox manifest version to 2 and use actual generated extension ID as ID.